### PR TITLE
Tweak: improves my colleague code keeping the `custom_field`

### DIFF
--- a/includes/class-public.php
+++ b/includes/class-public.php
@@ -263,8 +263,8 @@ class WooCommerceESPlugin {
 	 * Adds VAT info in WooCommerce PDF Invoices & Packing Slips
 	 */
 	public function wces_add_vat_invoices( $address, $document ) {
-		if ( ( $order = $document->order ) && ( $vat = $order->get_meta( '_billing_vat' ) ) ) {
-			$address .= sprintf( '<p>%1$s %2$s</p>', __( 'VAT info:', 'woocommerce-es' ), $vat );
+		if ( ! empty( $document ) && is_callable( array( $document, 'custom_field' ) ) ) {
+			$address .= sprintf( '<p>%s</p>', $document->custom_field( 'billing_vat', __( 'VAT info:', 'woocommerce-es' ) ) );
 		}
 		return $address;
 	}


### PR DESCRIPTION
This is an amend to this PR https://github.com/closemarketing/woocommerce-es/pull/3

It keeps using the `custom_field` method that you were using before, which is included in the document abstract and it's better to search order meta.